### PR TITLE
Add support for $_GET and $_POST

### DIFF
--- a/lib/middleman-php/middleware.rb
+++ b/lib/middleman-php/middleware.rb
@@ -13,7 +13,8 @@ module Middleman
           `echo #{Shellwords.escape(inject_params(env) + item)} | php`
         end
         headers['Content-Length'] = response.body.join.length.to_s
-        headers['Content-Type'] = 'text/html'
+        headers['Content-Type']   = 'text/html'
+        headers['Cache-Control']  = 'no-cache, no-store, must-revalidate'
       end
 
       [status, headers, response]


### PR DESCRIPTION
Took the params off the env and injected them before any PHP pre-processing making them available right away. All the parsing relies on PHP's [parse_str](http://www.php.net/manual/en/function.parse-str.php) function and works even for multilevel arrays.

Also added the Cache-Control header as a precaution because I'm not completely sure about the Rack caching internals.
