### PR TITLE
Fix content-length header for responses with multibyte characters.

### DIFF
--- a/lib/middleman-php/middleware.rb
+++ b/lib/middleman-php/middleware.rb
@@ -18,7 +18,7 @@ module Middleman
         response.body.map! do |item|
           execute_php(item)
         end
-        headers['Content-Length'] = response.body.join.length.to_s
+        headers['Content-Length'] = ::Rack::Utils.bytesize(response.body.join).to_s
         headers['Content-Type']   = 'text/html'
         headers['Cache-Control']  = 'no-cache, no-store, must-revalidate'
       end


### PR DESCRIPTION
Rack::Utils.bytesize seems to be the right choice, as it is also used by Middleman itself: https://github.com/middleman/middleman/blob/8eabe4d354a046f03766521faf42d589801cad36/middleman-core/lib/middleman-more/extensions/minify_css.rb#L56

Fixes “ERR_CONTENT_LENGTH_MISMATCH” error when trying to view the site in Chrome.
